### PR TITLE
Fixed a typo in the package name

### DIFF
--- a/code/requirements.txt
+++ b/code/requirements.txt
@@ -1,6 +1,6 @@
 Keras==1.2.1
 tqdm==4.10
-Thano==0.8.2
+Theano==0.8.2
 tensorflow-gpu==0.12.1
 gensim==13.3
 nltk==3.2.1


### PR DESCRIPTION
A package `Thano` doesn't exist, a package `Theano`, however, [exists in version 0.8.2](https://pypi.python.org/pypi/Theano/0.8.2) and seems to be a likely choice. I hope this assumption is correct!