### PR TITLE
Specify a package version that exists

### DIFF
--- a/code/requirements.txt
+++ b/code/requirements.txt
@@ -2,6 +2,6 @@ Keras==1.2.1
 tqdm==4.10
 Thano==0.8.2
 tensorflow-gpu==0.12.1
-gensim==13.3
+gensim==0.13.3
 nltk==3.2.1
 scipy==0.18.1


### PR DESCRIPTION
Version `13.3` of `gensim` doesn't exist whereas [version `0.13.3` exists](https://pypi.python.org/pypi/gensim/0.13.3). I hope I'm not wrong assuming you meant to require version `0.13.3` :)